### PR TITLE
Fix memory use after free (pointer to local variable outside its scope)

### DIFF
--- a/la_paper_test/false_position_newton.cpp
+++ b/la_paper_test/false_position_newton.cpp
@@ -642,7 +642,7 @@ void Bomb_Transport(std::unique_ptr<XS> const &xs, double P) {
                     #pragma omp atomic
                     escape += w;
                     #pragma omp atomic
-                    escape_sqr += w;
+                    escape_sqr += w*w;
                     #pragma omp atomic
                     cnts_sum += cnt;
                 } else {
@@ -711,7 +711,7 @@ void Meshed_Bomb_Transport(std::unique_ptr<XS> const &xs, double P) {
                         #pragma omp atomic
                         escape += w;
                         #pragma omp atomic
-                        escape_sqr += w;
+                        escape_sqr += w*w;
                         #pragma omp atomic
                         cnts_sum += cnt;
                     } else {
@@ -723,7 +723,7 @@ void Meshed_Bomb_Transport(std::unique_ptr<XS> const &xs, double P) {
                     #pragma omp atomic
                     escape += w;
                     #pragma omp atomic
-                    escape_sqr += w;
+                    escape_sqr += w*w;
                     #pragma omp atomic
                     cnts_sum += cnt;
                 } else {


### PR DESCRIPTION
This fixes a memory use problem that I detected with AddressSanitizer. I also chose to replace all naked pointers to XS objects with `std::unique_ptr<XS>`, which should make it more difficult to run into the same problem again.